### PR TITLE
fix crash: handle case where user has not been named yet

### DIFF
--- a/notifications.js
+++ b/notifications.js
@@ -1,3 +1,4 @@
+'use strict'
 var pull = require('pull-stream')
 var mlib = require('ssb-msgs')
 var multicb = require('multicb')
@@ -125,7 +126,7 @@ function getAbout(sbot, source, dest, cb) {
       }
     }, function (err) {
       if (err) return cb (err)
-      if (!name) name = truncate(id, 8)
+      if (!name) name = truncate(dest, 8)
       if (!image) gotImage()
       else getBlobFile(sbot, image, gotImage)
       function gotImage(path) {


### PR DESCRIPTION
This was crashing sbot if there are notifications from a feed that isn't named yet
(as happened when I was testing patchbay in firefox)

This _might_ be crashing on other people's machines too, so we should get this update out quick.
I have named my firefox self, so hopefully that mitigates it.
