### PR TITLE
Fix broken link in Mac notifications

### DIFF
--- a/notifications.js
+++ b/notifications.js
@@ -51,7 +51,7 @@ function getMsgLink(sbot, content, cb) {
 }
 
 function makeUrl(msg) {
-  return 'http://localhost:7777/#/msg/' + encodeURIComponent(msg.key)
+  return 'http://localhost:7777/#msg/' + encodeURIComponent(msg.key)
 }
 
 // Get filename for a blob


### PR DESCRIPTION
Remove slash after hash URI component to prevent encoding by terminal-notifier.
Terminal-notifier is hardcoded to encode hashes that are part of the segment and not part of the final query string, so the trailing slash causes terminal-notifier to encode that part of the URL, breaking the URL.