### PR TITLE
Sometimes sbot.private is null

### DIFF
--- a/notifications.js
+++ b/notifications.js
@@ -25,7 +25,7 @@ function trimMessage(msg) {
 
 function decryptPrivateMessage(sbot, msg, cb) {
   var content = msg && msg.value && msg.value.content
-  if (typeof content === 'string' && content.slice(-4) === '.box')
+  if (sbot.private && typeof content === 'string' && content.slice(-4) === '.box')
     sbot.private.unbox(content, function (err, content) {
       if (err && err.message === 'failed to decrypt') err = null
       if (err || !content) return cb(err)


### PR DESCRIPTION
I dunno if this is how I should fix this stuff but notifier was crashing sbot because it was null and with this it operates smoothly once more ¯\_(ツ)_/¯ 